### PR TITLE
memset zeros entire buffer in netlink oops

### DIFF
--- a/extra/oops_netlink_getsockbyportid_null_ptr.c
+++ b/extra/oops_netlink_getsockbyportid_null_ptr.c
@@ -50,7 +50,7 @@ int trigger_oops(void) {
   memset(iov,  0, sizeof(iov));
 
   int buf[64];
-  memset(buf, 0, 64);
+  memset(buf, 0, sizeof(buf));
 
   int s = socket(AF_NETLINK, SOCK_RAW, NETLINK_NETFILTER);
 


### PR DESCRIPTION
Haven't reviewed the code enough to know if this would have been an actual issue, but clang warned me about it when I did `make all` so I figured I'd send a PR.